### PR TITLE
generalize the forms no HTML allowed error message

### DIFF
--- a/schemas.js
+++ b/schemas.js
@@ -7,7 +7,7 @@ const extension = (joi) => ({
     type: 'string',
     base: joi.string(),
     messages: {
-        'string.escapeHTML': 'You cannot include HTML in the Add Maker form. Please try again.'
+        'string.escapeHTML': 'You cannot include HTML in The Wine and Cheese App forms. Please try again!'
     },
     rules: {
         escapeHTML: {


### PR DESCRIPTION
message generalized because it can be shown when users add a new maker or a new review.